### PR TITLE
#3 - PATCH requests sent by the Dynamics365 Request task don't have content & #4 - API 204 response handling

### DIFF
--- a/Frends.MicrosoftDynamics365.Request/CHANGELOG.md
+++ b/Frends.MicrosoftDynamics365.Request/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.0.1] - 2024-07-03
+## [1.1.0] - 2024-07-08
 ### Changed
 - Added support for PATCH requests and adjusted how the task handles responses from the Dynamics365 API if they have no content.
 

--- a/Frends.MicrosoftDynamics365.Request/CHANGELOG.md
+++ b/Frends.MicrosoftDynamics365.Request/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.1] - 2024-07-03
+### Changed
+- Added support for PATCH requests
+
 ## [1.0.0] - 2024-06-10
 ### Changed
 - Initial implementation

--- a/Frends.MicrosoftDynamics365.Request/CHANGELOG.md
+++ b/Frends.MicrosoftDynamics365.Request/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## [1.0.1] - 2024-07-03
 ### Changed
-- Added support for PATCH requests
+- Added support for PATCH requests and adjusted how the task handles responses from the Dynamics365 API if they have no content.
+
 
 ## [1.0.0] - 2024-06-10
 ### Changed
-- Initial implementation
+- Initial implementation.

--- a/Frends.MicrosoftDynamics365.Request/Frends.MicrosoftDynamics365.Request.Tests/UnitTests.cs
+++ b/Frends.MicrosoftDynamics365.Request/Frends.MicrosoftDynamics365.Request.Tests/UnitTests.cs
@@ -45,7 +45,7 @@ internal class UnitTests : TestsBase
 
         Assert.That(result.Success, Is.True);
         Assert.That(result.ErrorMessage, Is.Null);
-        Assert.AreEqual(result.Data.description.ToString(), "Updated description");
+        Assert.AreEqual(result.Data.description.ToString(), "Updated description.");
     }
 
     [Test]

--- a/Frends.MicrosoftDynamics365.Request/Frends.MicrosoftDynamics365.Request.Tests/UnitTests.cs
+++ b/Frends.MicrosoftDynamics365.Request/Frends.MicrosoftDynamics365.Request.Tests/UnitTests.cs
@@ -23,6 +23,32 @@ internal class UnitTests : TestsBase
     }
 
     [Test]
+    public async Task PatchAccount_UpdatesAccount()
+    {
+        // Get accounts and save the ID of the first one
+        var input = GetInput("accounts");
+        var options = GetOptions();
+
+        var result = await MicrosoftDynamics365.Request(input, options, CancellationToken.None);
+        var accountid = result.Data.value[0].accountid;
+
+        // Update the description of the first returned account with a PATCH
+        input = GetInput($"accounts({accountid})", Method.PATCH, "{\r\n\"description\": \"Updated description.\"\r\n}");
+        result = await MicrosoftDynamics365.Request(input, options, CancellationToken.None);
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.ErrorMessage, Is.Null);
+
+        // Get account description and assert that it has been updated
+        input = GetInput($"accounts({accountid})?$select=description");
+        result = await MicrosoftDynamics365.Request(input, options, CancellationToken.None);
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.ErrorMessage, Is.Null);
+        Assert.AreEqual(result.Data.description.ToString(), "Updated description");
+    }
+
+    [Test]
     public async Task BadAuthentication_ReturnsError()
     {
         var input = new Input { ClientId = "bad", ClientSecret = "bad", };

--- a/Frends.MicrosoftDynamics365.Request/Frends.MicrosoftDynamics365.Request/Frends.MicrosoftDynamics365.Request.cs
+++ b/Frends.MicrosoftDynamics365.Request/Frends.MicrosoftDynamics365.Request/Frends.MicrosoftDynamics365.Request.cs
@@ -94,7 +94,7 @@ public static class MicrosoftDynamics365
         }
 
         var jsonResponse = await response.Content.ReadAsStringAsync(cancellationToken);
-        var contacts = !string.IsNullOrWhiteSpace(jsonResponse) ? JToken.Parse(jsonResponse) : JToken.Parse("{\r\n\"message\": \"Success\"\r\n}");
-        return contacts;
+        var parsedResponse = !string.IsNullOrWhiteSpace(jsonResponse) ? JToken.Parse(jsonResponse) : null;
+        return parsedResponse;
     }
 }

--- a/Frends.MicrosoftDynamics365.Request/Frends.MicrosoftDynamics365.Request/Frends.MicrosoftDynamics365.Request.cs
+++ b/Frends.MicrosoftDynamics365.Request/Frends.MicrosoftDynamics365.Request/Frends.MicrosoftDynamics365.Request.cs
@@ -94,7 +94,7 @@ public static class MicrosoftDynamics365
         }
 
         var jsonResponse = await response.Content.ReadAsStringAsync(cancellationToken);
-        var contacts = JToken.Parse(jsonResponse);
+        var contacts = !string.IsNullOrWhiteSpace(jsonResponse) ? JToken.Parse(jsonResponse) : JToken.Parse("{\r\n\"message\": \"Success\"\r\n}");
         return contacts;
     }
 }

--- a/Frends.MicrosoftDynamics365.Request/Frends.MicrosoftDynamics365.Request/Frends.MicrosoftDynamics365.Request.cs
+++ b/Frends.MicrosoftDynamics365.Request/Frends.MicrosoftDynamics365.Request/Frends.MicrosoftDynamics365.Request.cs
@@ -79,7 +79,7 @@ public static class MicrosoftDynamics365
             RequestUri = new Uri($"{input.Dynamics365Url}/api/data/{options.ApiVersion}/{input.Path}"),
         };
 
-        if (input.Method == Method.POST || input.Method == Method.PUT)
+        if (input.Method == Method.POST || input.Method == Method.PUT || input.Method == Method.PATCH)
         {
             request.Content = new StringContent(input.Payload ?? string.Empty, System.Text.Encoding.UTF8, "application/json");
         }

--- a/Frends.MicrosoftDynamics365.Request/Frends.MicrosoftDynamics365.Request/Frends.MicrosoftDynamics365.Request.csproj
+++ b/Frends.MicrosoftDynamics365.Request/Frends.MicrosoftDynamics365.Request/Frends.MicrosoftDynamics365.Request.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
 	  <TargetFramework>net6.0</TargetFramework>
 	  <LangVersion>Latest</LangVersion>
-	  <Version>1.0.0</Version>
+	  <Version>1.1.0</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
closes #3
closes #4

- #3: `Method.PATCH` wasn't included in the `if` that checks whether or not the request should have content or not. 😄 

- #4: Added an if statement that checks whether or not the response content was empty before parsing it into a JToken.

- Created a unit test that updates the description of one account in the test instance with PATCH and verifies that the description was updated. (This test also verifies that the response handling is working, since the API response to a successful PATCH request is 204)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for PATCH requests in the Frends.MicrosoftDynamics365.Request module.

- **Bug Fixes**
  - Improved handling of responses with no content from the Dynamics365 API.

- **Tests**
  - Added a new test method to ensure PATCH requests update account descriptions correctly.

- **Chores**
  - Updated module version to 1.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->